### PR TITLE
Fixed defineProperty error

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -60,7 +60,9 @@ export default class Form extends (PureComponent || Component) {
 
       return wrapper;
     };
-    Object.defineProperty(wrapper, 'name', { value: name, enumerable: true });
+    if (Object.getOwnPropertyDescriptor(wrapper, 'name').configurable) {
+      Object.defineProperty(wrapper, 'name', { value: name, enumerable: true });
+    }
     Object.assign(wrapper, {
       value: this.get(name),
       onChange: handler,


### PR DESCRIPTION
There is an error - TypeError: Attempting to change enumerable attribute of unconfigurable property.

Function's name is not configurable in old browsers (IE or Safari).
`Note that in non-standard, pre-ES2015 implementations the configurable
attribute was false as well.`
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
I decided that name prop is not so important and we can neglect it